### PR TITLE
Add note for people suspicous of discord rpc libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ dacha<br>
 svintus<br>
 daisy<br>
 and more i might have forgot
+
+#### NOTE: For those suspicious of the discord rpc binaries
+Simply replace them with the ones you can download [here](https://github.com/discord/discord-rpc/releases)
+ 


### PR DESCRIPTION
Saw some people attacking Yoink for including these libs, claiming they were malware, might as well add a note in the readme to let people replace them if they think the binaries are malicious.